### PR TITLE
Update pownMyHash.sh with random rules

### DIFF
--- a/pownMyHash.sh
+++ b/pownMyHash.sh
@@ -513,6 +513,14 @@ fi
 
 loopOnPotfile
 
+# No more idea ? Use generate-rules, according to hashcat this is a good thing if you are out of ideas on what to do next when you have already tried all your rules on all your dictionaries
+if title "Infinite loop with random rules"; then
+    while true
+    do
+        hashcat 0 `absPath $dico` --generate-rules=40000000 --debug-mode=1 --debug-file=$STATS_DIR/matched-random.rules
+    done
+fi
+
 for dico in `echo $FINDINGS; find $DICO_PATH/ -name '*.rank' -size -15M -type f`; do
 	if title "Brute force password with $dico base"; then
 		stats_on $dico "BRUTEFORCE"


### PR DESCRIPTION
Use the option `generate-rules` of `hashcat` to generate random rules.
According to [hashcat](https://hashcat.net/wiki/doku.php?id=rule_based_attack#generating_rules):
> This is a good thing if you are out of ideas on what to do next when you have already tried all your rules on all your dictionaries

Save all rules that have matched to use them later.